### PR TITLE
chore: 添加订阅模块启用的前置条件文本信息

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -480,6 +480,7 @@ spec:
           id: subscribe
           key: subscribe
           label: 订阅模块
+          help: 依赖前置插件“文章订阅”，https://www.halo.run/store/apps/app-yldNX
           children:
             - $formkit: select
               name: subscribe_enabled


### PR DESCRIPTION
<img width="683" height="523" alt="image" src="https://github.com/user-attachments/assets/7151ca93-3d82-4352-ad53-8948925f8575" />
